### PR TITLE
Removing CLASSPATH from the environment when launching lein in a shell subprocess

### DIFF
--- a/src/leiningen/modules.clj
+++ b/src/leiningen/modules.clj
@@ -191,7 +191,8 @@ Accepts '-q', '--quiet' and ':quiet' to suppress non-subprocess output."
           (println " Building" (:name project) (:version project) (dump-profiles args))
           (println "------------------------------------------------------------------------"))
         (if-let [cmd (get-in project [:modules :subprocess] subprocess)]
-          (binding [eval/*dir* (:root project)]
+          (binding [eval/*dir* (:root project)
+                    eval/*env* (with-meta (dissoc (into {} (System/getenv)) "CLASSPATH") {:replace true})]
             (let [exit-code (apply eval/sh (cons cmd args))]
               (when (pos? exit-code)
                 (throw (ex-info "Subprocess failed" {:exit-code exit-code})))))


### PR DESCRIPTION
Found this change in the wild, going to see if I can test it in CMR